### PR TITLE
fix: 修復 Mac 待機後 socket 斷線導致「房間不存在」問題

### DIFF
--- a/app/multiple-play/[roomId]/page.tsx
+++ b/app/multiple-play/[roomId]/page.tsx
@@ -12,6 +12,7 @@ import EditRoomModal from '@/components/modals/edit-room-modal';
 import EnterRoomPasswordModal from '@/components/modals/enter-room-password-modal';
 import { GameOverModal } from '@/components/modals/game-over-modal';
 import { PlayerNameModal } from '@/components/modals/player-name-modal';
+import { ReconnectOverlay } from '@/components/modals/reconnect-overlay';
 import RemoveRoomPlayerModal from '@/components/modals/remove-room-player-modal';
 import { Button } from '@/components/ui/button';
 import {
@@ -54,6 +55,7 @@ export default function RoomPage() {
     gameOverData,
     onCloseGameOver,
     gameAbortedData,
+    connectionStatus,
   } = useMultiplePlay();
 
   useEffect(() => {
@@ -154,6 +156,14 @@ export default function RoomPage() {
 
   return (
     <>
+      <ReconnectOverlay
+        status={connectionStatus}
+        onLeave={() => {
+          sessionStorage.removeItem('reconnectToken');
+          sessionStorage.removeItem('reconnectRoomId');
+          router.push('/multiple-play');
+        }}
+      />
       {gameOverData && (
         <GameOverModal
           isOpen={!!gameOverData}

--- a/components/homepage.tsx
+++ b/components/homepage.tsx
@@ -203,7 +203,7 @@ const Homepage = () => {
       <footer className="fixed bottom-4 left-1/2 w-full -translate-x-1/2">
         <div className="mb-1 flex items-center justify-center text-xs text-gray-500">
           <div>此網站在電腦與平板支援度最佳</div>
-          <div className="mx-2 text-xs text-gray-500">v1.0.3</div>
+          <div className="mx-2 text-xs text-gray-500">v1.0.4</div>
           <Link
             href="https://github.com/JohnsonHuang555/24_points"
             target="_blank"

--- a/components/modals/reconnect-overlay.tsx
+++ b/components/modals/reconnect-overlay.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+type Props = {
+  status: 'connected' | 'reconnecting' | 'disconnected';
+  onLeave: () => void;
+};
+
+export function ReconnectOverlay({ status, onLeave }: Props) {
+  if (status === 'connected') return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/70 backdrop-blur-sm">
+      {status === 'reconnecting' ? (
+        <>
+          <div className="mb-6 h-14 w-14 animate-spin rounded-full border-4 border-white/30 border-t-white" />
+          <p className="text-xl font-semibold text-white">連線中斷，正在嘗試重新連線...</p>
+          <p className="mt-2 text-sm text-white/60">請稍候，勿關閉此頁面</p>
+        </>
+      ) : (
+        <>
+          <div className="mb-6 text-6xl">⚠️</div>
+          <p className="text-xl font-semibold text-white">已與伺服器斷線</p>
+          <p className="mt-2 text-sm text-white/60">無法重新連線，遊戲已結束</p>
+          <button
+            onClick={onLeave}
+            className="mt-8 rounded-lg bg-white px-6 py-2 font-semibold text-black transition hover:bg-white/90"
+          >
+            回到大廳
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/modals/rule-modal.tsx
+++ b/components/modals/rule-modal.tsx
@@ -36,7 +36,7 @@ export function RuleModal({ isOpen, onOpenChange }: RuleModalProps) {
                   <li>• 玩家有 <strong>4</strong> 張手牌</li>
                   <li>• 使用手牌組出等於 24 的算式並出牌，必須用完所有手牌</li>
                   <li>• 無法組出算式時可選擇<strong>跳過</strong>，換全部 4 張新牌，無得分</li>
-                  <li>• 牌庫耗盡時進入最後一輪，玩家回合結束後遊戲結束，得分最高者獲勝</li>
+                  <li>• 牌庫耗盡時進入最後一輪，玩家回合結束後遊戲結束</li>
                 </ul>
               </section>
               <section>

--- a/models/Player.ts
+++ b/models/Player.ts
@@ -21,4 +21,7 @@ export type Player = {
   hasMelded: boolean; // 是否已破冰（拉密模式）
   isBot?: boolean; // 是否為 AI 玩家
   botDifficulty?: 'easy' | 'normal' | 'hard'; // AI 難度
+  reconnectToken?: string; // 斷線重連令牌（UUID），跨重連使用
+  isDisconnected?: boolean; // 是否處於暫時斷線（寬限期中）
+  disconnectedAt?: number; // 斷線時間戳（ms）
 };

--- a/models/SocketEvent.ts
+++ b/models/SocketEvent.ts
@@ -42,4 +42,10 @@ export enum SocketEvent {
   GameOver = 'game-over',
   GameAborted = 'game-aborted',
   CountdownTimeResponse = 'countdown-time-response',
+
+  // 斷線重連相關
+  GetReconnectToken = 'get-reconnect-token',
+  PlayerReconnect = 'player-reconnect',
+  PlayerReconnectSuccess = 'player-reconnect-success',
+  PlayerReconnectFailed = 'player-reconnect-failed',
 }

--- a/providers/multiple-play-provider.tsx
+++ b/providers/multiple-play-provider.tsx
@@ -92,6 +92,7 @@ type MultiplePlayContextData = {
   onCloseGameOver: () => void;
   gameAbortedData: GameAbortedData | null;
   addBot: (difficulty: 'easy' | 'normal' | 'hard') => void;
+  connectionStatus: 'connected' | 'reconnecting' | 'disconnected';
 };
 const MultiplePlayContext = createContext<MultiplePlayContextData | undefined>(
   undefined,
@@ -121,6 +122,8 @@ export function MultiplePlayProvider({ children }: MultiplePlayProviderProps) {
   }>();
   const [gameOverData, setGameOverData] = useState<GameOverData | null>(null);
   const [gameAbortedData, setGameAbortedData] = useState<GameAbortedData | null>(null);
+  const [connectionStatus, setConnectionStatus] = useState<'connected' | 'reconnecting' | 'disconnected'>('connected');
+  const graceTimerRef = useRef<NodeJS.Timeout | null>(null);
   const {
     selectedCardSymbols,
     selectedCardNumbers,
@@ -170,6 +173,40 @@ export function MultiplePlayProvider({ children }: MultiplePlayProviderProps) {
     socket.on(SocketEvent.GetPlayerId, (id: string) => {
       setPlayerId(id);
       playerIdRef.current = id;
+    });
+
+    socket.on(SocketEvent.GetReconnectToken, (token: string) => {
+      sessionStorage.setItem('reconnectToken', token);
+    });
+
+    // 斷線：顯示重連中 UI
+    socket.on('disconnect', () => {
+      setConnectionStatus('reconnecting');
+      graceTimerRef.current = setTimeout(() => {
+        setConnectionStatus('disconnected');
+      }, 30_000);
+    });
+
+    // 重連成功後（manager 事件，僅在真正重連後觸發，不含初次連線）
+    socket.io.on('reconnect', () => {
+      const token = sessionStorage.getItem('reconnectToken');
+      if (token) {
+        socket.emit(SocketEvent.PlayerReconnect, { reconnectToken: token });
+      }
+    });
+
+    socket.on(SocketEvent.PlayerReconnectSuccess, ({ room }: { room: Room }) => {
+      if (graceTimerRef.current) clearTimeout(graceTimerRef.current);
+      setRoomInfo(room);
+      setConnectionStatus('connected');
+      toast.success('已重新連線');
+    });
+
+    socket.on(SocketEvent.PlayerReconnectFailed, () => {
+      if (graceTimerRef.current) clearTimeout(graceTimerRef.current);
+      setConnectionStatus('disconnected');
+      sessionStorage.removeItem('reconnectToken');
+      sessionStorage.removeItem('reconnectRoomId');
     });
 
     socket.on(
@@ -254,6 +291,9 @@ export function MultiplePlayProvider({ children }: MultiplePlayProviderProps) {
       remainSeconds?: number | null,
     ) => {
       if (socket) {
+        // 主動加入房間時，清除舊的重連令牌（避免誤觸重連邏輯）
+        sessionStorage.removeItem('reconnectToken');
+        sessionStorage.setItem('reconnectRoomId', roomId);
         socket.emit(SocketEvent.JoinRoom, {
           playerName,
           roomId,
@@ -540,9 +580,11 @@ export function MultiplePlayProvider({ children }: MultiplePlayProviderProps) {
       onRummySubmit,
       onSwapJoker,
       addBot,
+      connectionStatus,
     };
   }, [
     checkAnswerCorrect,
+    connectionStatus,
     currentPlayer,
     editRoom,
     editRoomSettings,

--- a/server/game.ts
+++ b/server/game.ts
@@ -27,7 +27,7 @@ import {
 } from './utils';
 
 type JoinRoomResult =
-  | { success: true; room: Room }
+  | { success: true; room: Room; reconnectToken: string }
   | { success: false; error: string; needPassword?: true };
 
 type DrawCardResult =
@@ -50,6 +50,8 @@ type SkipHandResult =
 let _rooms: Room[] = [];
 // 玩家在房間資訊
 const _playerInRoomMap: { [key: string]: string } = {};
+// reconnectToken → { playerId, roomId } 的映射（重連時用）
+const _tokenToPlayerMap: Map<string, { playerId: string; roomId: string }> = new Map();
 
 // 取得當前房間 需濾掉單人遊戲
 export function getCurrentRooms(payload?: {
@@ -224,7 +226,10 @@ export function joinRoom(
       );
       const isMaster = _rooms[roomIndex].players[playerIndex]?.isMaster;
       if (isMaster) {
-        return { success: true, room: _rooms[roomIndex] };
+        const masterToken = _rooms[roomIndex].players[playerIndex].reconnectToken ?? uuidv4();
+        _rooms[roomIndex].players[playerIndex].reconnectToken = masterToken;
+        _tokenToPlayerMap.set(masterToken, { playerId, roomId: payload.roomId });
+        return { success: true, room: _rooms[roomIndex], reconnectToken: masterToken };
       }
 
       // 當房間有設密碼且不是房主需要回傳密碼輸入事件
@@ -238,6 +243,7 @@ export function joinRoom(
       }
 
       // 房間已存在且不是房主
+      const newPlayerToken = uuidv4();
       _rooms[roomIndex].players.push({
         id: playerId,
         isMaster: false,
@@ -247,9 +253,11 @@ export function joinRoom(
         isLastRoundPlayer: false,
         isReady: false,
         hasMelded: false,
+        reconnectToken: newPlayerToken,
       });
+      _tokenToPlayerMap.set(newPlayerToken, { playerId, roomId: payload.roomId });
 
-      return { success: true, room: _rooms[roomIndex] };
+      return { success: true, room: _rooms[roomIndex], reconnectToken: newPlayerToken };
     } else {
       // 沒有房間名稱，表示房間已經被刪除剛好有玩家加入時
       if (mode === GameMode.Multiple && !payload.roomName) {
@@ -263,6 +271,7 @@ export function joinRoom(
         if (existRoomName) return { success: false, error: '房間名稱已存在' };
       }
       // 創建新房間
+      const masterToken = uuidv4();
       const newRoom: Room = {
         roomId: payload.roomId,
         maxPlayers: payload.maxPlayers,
@@ -290,12 +299,14 @@ export function joinRoom(
             isLastRoundPlayer: false,
             isReady: true,
             hasMelded: false,
+            reconnectToken: masterToken,
           },
         ],
       };
       _rooms.push(newRoom);
+      _tokenToPlayerMap.set(masterToken, { playerId, roomId: payload.roomId });
 
-      return { success: true, room: newRoom };
+      return { success: true, room: newRoom, reconnectToken: masterToken };
     }
   } catch (e) {
     return { success: false, error: '發生錯誤，請稍後再試 (join room)' };
@@ -368,6 +379,51 @@ export function leaveRoom(
     wasPlaying,
     remainingCount: newPlayers.length,
   };
+}
+
+// 將玩家標記為暫時斷線（寬限期中，不立即移除）
+export function markPlayerDisconnected(playerId: string):
+  | { roomId: string; room: Room; playerName: string; reconnectToken: string }
+  | undefined {
+  const roomId = _playerInRoomMap[playerId];
+  const room = _getCurrentRoom(roomId);
+  if (!room || !roomId) return undefined;
+
+  const player = room.players.find(p => p.id === playerId);
+  if (!player || !player.reconnectToken) return undefined;
+
+  player.isDisconnected = true;
+  player.disconnectedAt = Date.now();
+
+  return { roomId, room, playerName: player.name, reconnectToken: player.reconnectToken };
+}
+
+// 玩家重連：以新 socket.id 恢復舊玩家狀態
+export function reconnectPlayer(
+  newSocketId: string,
+  reconnectToken: string,
+): { success: true; room: Room; playerName: string } | { success: false; error: string } {
+  const entry = _tokenToPlayerMap.get(reconnectToken);
+  if (!entry) return { success: false, error: '重連令牌無效或已過期' };
+
+  const { playerId: oldPlayerId, roomId } = entry;
+  const room = _getCurrentRoom(roomId);
+  if (!room) return { success: false, error: '房間不存在' };
+
+  const player = room.players.find(p => p.id === oldPlayerId);
+  if (!player) return { success: false, error: '玩家資料不存在' };
+
+  // 更新玩家 ID 為新的 socket.id，清除斷線狀態
+  player.id = newSocketId;
+  player.isDisconnected = false;
+  player.disconnectedAt = undefined;
+
+  // 更新映射表
+  delete _playerInRoomMap[oldPlayerId];
+  _playerInRoomMap[newSocketId] = roomId;
+  _tokenToPlayerMap.set(reconnectToken, { playerId: newSocketId, roomId });
+
+  return { success: true, room, playerName: player.name };
 }
 
 // 開始遊戲

--- a/server/index.ts
+++ b/server/index.ts
@@ -17,8 +17,10 @@ import {
   getPlayerName,
   joinRoom,
   leaveRoom,
+  markPlayerDisconnected,
   playCard,
   readyGame,
+  reconnectPlayer,
   removePlayer,
   reselectCard,
   rummyBotPlay,
@@ -42,6 +44,9 @@ const handler = app.getRequestHandler();
 const timerMap: {
   [key: string]: { timer: NodeJS.Timeout | null; countdownTime: number };
 } = {};
+
+// 斷線寬限期計時器 Map：key = reconnectToken, value = setTimeout handle
+const disconnectGraceTimerMap: Map<string, NodeJS.Timeout> = new Map();
 
 app.prepare().then(() => {
   const httpServer = createServer(handler);
@@ -130,6 +135,7 @@ app.prepare().then(() => {
           if (result.success) {
             io.sockets.to(roomId).emit(SocketEvent.JoinRoomSuccess, result.room);
             socket.emit(SocketEvent.GetPlayerId, playerId);
+            socket.emit(SocketEvent.GetReconnectToken, result.reconnectToken);
           } else if (result.needPassword) {
             socket.emit(SocketEvent.NeedRoomPassword);
           } else {
@@ -467,40 +473,102 @@ app.prepare().then(() => {
       }
     });
 
-    socket.on('disconnect', () => {
-      const leaveResult = leaveRoom(playerId);
-      if (leaveResult) {
-        const roomId = leaveResult.room.roomId;
-        const { room, playerName, wasPlaying, remainingCount } = leaveResult;
+    socket.on('disconnect', (reason) => {
+      // 用戶主動斷線（切換頁面、關閉分頁）→ 立即移除
+      // 非主動斷線（Mac 待機、網路中斷）→ 30 秒寬限期
+      const isIntentional =
+        reason === 'client namespace disconnect' || reason === 'server namespace disconnect';
 
-        io.sockets.to(roomId).emit(SocketEvent.RoomUpdate, { room });
+      if (isIntentional) {
+        const leaveResult = leaveRoom(playerId);
+        if (leaveResult) {
+          const roomId = leaveResult.room.roomId;
+          const { room, playerName, wasPlaying, remainingCount } = leaveResult;
 
-        if (wasPlaying && remainingCount <= 1) {
-          // 遊戲中且剩餘 ≤ 1 人：遊戲中斷
-          io.sockets.to(roomId).emit(SocketEvent.GameAborted, playerName);
-          // 清除計時器
-          if (timerMap[roomId]?.timer !== null) {
-            clearInterval(timerMap[roomId].timer as NodeJS.Timeout);
-            delete timerMap[roomId];
-          }
-        } else {
-          // 一般離開（toast）
-          io.sockets.to(roomId).emit(SocketEvent.PlayerLeaveRoom, playerName);
+          io.sockets.to(roomId).emit(SocketEvent.RoomUpdate, { room });
 
-          if (wasPlaying && remainingCount >= 2) {
-            // 遊戲繼續：重置計時器給下一位玩家
-            if (timerMap[roomId] && room.settings.remainSeconds !== null) {
-              _clearAndCreateTimer(roomId, room);
-            }
-          } else {
-            // 大廳狀態：清除計時器
+          if (wasPlaying && remainingCount <= 1) {
+            io.sockets.to(roomId).emit(SocketEvent.GameAborted, playerName);
             if (timerMap[roomId]?.timer !== null) {
               clearInterval(timerMap[roomId].timer as NodeJS.Timeout);
               delete timerMap[roomId];
             }
+          } else {
+            io.sockets.to(roomId).emit(SocketEvent.PlayerLeaveRoom, playerName);
+
+            if (wasPlaying && remainingCount >= 2) {
+              if (timerMap[roomId] && room.settings.remainSeconds !== null) {
+                _clearAndCreateTimer(roomId, room);
+              }
+            } else {
+              if (timerMap[roomId]?.timer !== null) {
+                clearInterval(timerMap[roomId].timer as NodeJS.Timeout);
+                delete timerMap[roomId];
+              }
+            }
           }
         }
+      } else {
+        // 非主動斷線：標記為暫時斷線，給予 30 秒寬限期
+        const markResult = markPlayerDisconnected(playerId);
+        if (!markResult) return;
+
+        const { roomId, room, reconnectToken } = markResult;
+        io.sockets.to(roomId).emit(SocketEvent.RoomUpdate, { room });
+
+        const graceTimer = setTimeout(() => {
+          disconnectGraceTimerMap.delete(reconnectToken);
+
+          const leaveResult = leaveRoom(playerId);
+          if (leaveResult) {
+            const { room: updatedRoom, playerName, wasPlaying, remainingCount } = leaveResult;
+
+            io.sockets.to(roomId).emit(SocketEvent.RoomUpdate, { room: updatedRoom });
+
+            if (wasPlaying && remainingCount <= 1) {
+              io.sockets.to(roomId).emit(SocketEvent.GameAborted, playerName);
+              if (timerMap[roomId]?.timer !== null) {
+                clearInterval(timerMap[roomId].timer as NodeJS.Timeout);
+                delete timerMap[roomId];
+              }
+            } else {
+              io.sockets.to(roomId).emit(SocketEvent.PlayerLeaveRoom, playerName);
+
+              if (wasPlaying && remainingCount >= 2) {
+                if (timerMap[roomId] && updatedRoom.settings.remainSeconds !== null) {
+                  _clearAndCreateTimer(roomId, updatedRoom);
+                }
+              } else {
+                if (timerMap[roomId]?.timer !== null) {
+                  clearInterval(timerMap[roomId].timer as NodeJS.Timeout);
+                  delete timerMap[roomId];
+                }
+              }
+            }
+          }
+        }, 30_000);
+
+        disconnectGraceTimerMap.set(reconnectToken, graceTimer);
       }
+    });
+
+    socket.on(SocketEvent.PlayerReconnect, ({ reconnectToken }: { reconnectToken: string }) => {
+      // 取消寬限期計時器
+      const graceTimer = disconnectGraceTimerMap.get(reconnectToken);
+      if (graceTimer) {
+        clearTimeout(graceTimer);
+        disconnectGraceTimerMap.delete(reconnectToken);
+      }
+
+      const result = reconnectPlayer(playerId, reconnectToken);
+      if (!result.success) {
+        socket.emit(SocketEvent.PlayerReconnectFailed, { error: result.error });
+        return;
+      }
+
+      socket.join(result.room.roomId);
+      socket.emit(SocketEvent.PlayerReconnectSuccess, { room: result.room });
+      io.sockets.to(result.room.roomId).emit(SocketEvent.RoomUpdate, { room: result.room });
     });
   });
 


### PR DESCRIPTION
- 服務器斷線時依原因區分主動/被動：被動斷線給予 30 秒寬限期
- 新增 reconnectToken（UUID）機制，跨重連識別玩家身份
- 客戶端重連後自動攜帶令牌請求恢復遊戲狀態
- 新增 ReconnectOverlay 元件顯示重連中/已斷線 UI