### PR TITLE
修正排行榜沒有被正確更新的問題

### DIFF
--- a/components/announcement-banner.tsx
+++ b/components/announcement-banner.tsx
@@ -41,7 +41,7 @@ const AnnouncementBanner = () => {
               新模式「心算快答」上線！
             </span>
             <span className="hidden text-sm text-white/75 sm:inline">
-              10 題限時心算連續快答・答錯罰時、比拚總秒數・全球排行榜榜競速
+              10 題限時心算連續快答・答錯罰時、比拚總秒數・全球排行榜競速
             </span>
             <Link
               href="/quick-math"

--- a/components/modals/leaderboard-modal.tsx
+++ b/components/modals/leaderboard-modal.tsx
@@ -251,7 +251,7 @@ export function LeaderboardModal({
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <Trophy className="h-5 w-5 text-yellow-500" />
-              全球排行榜榜
+              全球排行榜
             </DialogTitle>
           </DialogHeader>
 

--- a/hooks/useLeaderboardSubmit.ts
+++ b/hooks/useLeaderboardSubmit.ts
@@ -15,7 +15,12 @@ export function useLeaderboardSubmit(
   const submittedRef = useRef(false);
 
   useEffect(() => {
-    if (!enabled || !payload || submittedRef.current) return;
+    if (!enabled || !payload) {
+      // 開新局（回到未完賽狀態）時重置，下次完賽才能再提交
+      submittedRef.current = false;
+      return;
+    }
+    if (submittedRef.current) return;
 
     const hasGoogle = !!session?.user;
     const hasGuest = !!guestId && !!guestName;


### PR DESCRIPTION
當 enabled 或 payload 變回 falsy（也就是按「再玩一次」回到未完賽狀態）時，把 submittedRef 重置為 false，下一局完賽時就會重新發出提交請求。同一局內的重複提交防護維持不變。npx tsc --noEmit 型別檢查通過。

因為快答、每日競速、挑戰模式都共用這個 hook，一次全部修好。